### PR TITLE
do NOT sort vocab lazily, because in a canister query you re-do it

### DIFF
--- a/icpp_llama2/src/run.c
+++ b/icpp_llama2/src/run.c
@@ -492,15 +492,17 @@ void encode(Tokenizer* t, const char *text, int8_t bos, int8_t eos, int *tokens,
         // fprintf(stderr, "cannot encode NULL text\n"); exit(EXIT_FAILURE); 
         }
 
-    if (t->sorted_vocab == NULL) {
-        // lazily malloc and sort the vocabulary
-        t->sorted_vocab = malloc(t->vocab_size * sizeof(TokenIndex));
-        for (int i = 0; i < t->vocab_size; i++) {
-            t->sorted_vocab[i].str = t->vocab[i];
-            t->sorted_vocab[i].id = i;
-        }
-        qsort(t->sorted_vocab, t->vocab_size, sizeof(TokenIndex), compare_tokens);
-    }
+    // ICPP: we do not want to do this lazily, because during a query, it is not stored
+    //       instead, we do this as part of initialize.cpp
+    // if (t->sorted_vocab == NULL) {
+    //     // lazily malloc and sort the vocabulary
+    //     t->sorted_vocab = malloc(t->vocab_size * sizeof(TokenIndex));
+    //     for (int i = 0; i < t->vocab_size; i++) {
+    //         t->sorted_vocab[i].str = t->vocab[i];
+    //         t->sorted_vocab[i].id = i;
+    //     }
+    //     qsort(t->sorted_vocab, t->vocab_size, sizeof(TokenIndex), compare_tokens);
+    // }
 
     // create a temporary buffer that will store merge candidates of always two consecutive tokens
     // *2 for concat, +1 for null terminator +2 for UTF8 (in case max_token_length is 1)

--- a/icpp_llama2/src/run.h
+++ b/icpp_llama2/src/run.h
@@ -104,6 +104,7 @@ extern Sampler sampler;
 // At inference
 extern unsigned long long rng_seed;
 
+int compare_tokens(const void *a, const void *b);
 bool malloc_run_state(RunState *s, Config *p);
 void memory_map_weights(TransformerWeights *w, Config *p, float *ptr,
                         int shared_weights);


### PR DESCRIPTION
Sort it once during canister initialization, which is an `update` call.

Doing it lazily during inference is not good, because that is a `query` call and it will be repeated each time.